### PR TITLE
webhook: remove configurability; always use /webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Spotted Arms is a small Rust service that listens for GitHub `workflow_job` webh
 - Health and ping endpoints
 
 ## Endpoints
-- `POST /webhook` — GitHub webhook receiver for `workflow_job` events (default; configurable via `WEBHOOK_PATH` or `--webhook-path`)
+- `POST /webhook` — GitHub webhook receiver for `workflow_job` events
 - `GET /ping` — simple liveness probe (returns `pong`)
 - `POST /health_check` — returns JSON status and request headers
 
@@ -76,12 +76,12 @@ This service intentionally avoids baked‑in defaults. Provide configuration via
    PORT=9090 cargo run --bin spotted-arms
    ```
 
-3. Send a test webhook payload (ensure the signature/secret matches) to `http://localhost:3000/webhook` (or your configured path).
+3. Send a test webhook payload (ensure the signature/secret matches) to `http://localhost:3000/webhook`.
 
 ## Deploying
 - Run as a service on GCE/GKE/Cloud Run with the above environment.
 - Ensure the service account has the Compute and Trace permissions listed.
-- Configure your GitHub App webhook to point at `https://<your-host>/webhook` (or your configured path) and set the same shared secret used in `GITHUB_CREDENTIALS`.
+- Configure your GitHub App webhook to point at `https://<your-host>/webhook` and set the same shared secret used in `GITHUB_CREDENTIALS`.
 
 ## How it works
 - Webhook handler validates the request and inspects `workflow_job` events.
@@ -114,6 +114,5 @@ Available flags
 - `--project-id` (env: `GOOGLE_CLOUD_PROJECT`) — 🏷️ Google Cloud project ID. Also sets `GCP_PROJECT` for compatibility.
 - `--zone` (env: `GOOGLE_CLOUD_ZONE`) — 📍 Google Cloud zone (e.g., `us-central1-f`).
 - `--telemetry-project-id` (env: `PROJECT_ID`) — 📊 Cloud Trace project override.
-- `--webhook-path` (env: `WEBHOOK_PATH`) — 🔔 Webhook endpoint path. Default: `/webhook`.
 
 Contributions and improvements welcome!

--- a/src/bin/spotted-arms.rs
+++ b/src/bin/spotted-arms.rs
@@ -34,14 +34,6 @@ struct Cli {
     /// 📊 Cloud Trace project override for telemetry
     #[arg(long = "telemetry-project-id", env = "PROJECT_ID")]
     telemetry_project_id: Option<String>,
-
-    /// 🔔 Webhook endpoint path (default: /webhook)
-    #[arg(
-        long = "webhook-path",
-        env = "WEBHOOK_PATH",
-        default_value = "/webhook"
-    )]
-    webhook_path: String,
 }
 
 #[tokio::main]
@@ -98,19 +90,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .await?;
 
-    // Normalize webhook path and build app
-    let mut webhook_path = cli.webhook_path.clone();
-    if webhook_path.is_empty() || webhook_path == "/" {
-        info!(
-            "Invalid WEBHOOK_PATH '{}'; defaulting to /webhook",
-            webhook_path
-        );
-        webhook_path = "/webhook".to_string();
-    }
-    if !webhook_path.starts_with('/') {
-        webhook_path = format!("/{}", webhook_path);
-    }
-    let app = spotted_arms::server::create_app(state, &webhook_path);
+    // Build app with fixed webhook path (/webhook)
+    let app = spotted_arms::server::create_app(state);
 
     // Determine port
     // Note: if neither PORT env nor --port is passed, default is 3000

--- a/src/server.rs
+++ b/src/server.rs
@@ -95,12 +95,9 @@ pub async fn health_check(request: Request<Body>) -> String {
 }
 
 /// Creates the Axum router with all routes and middleware configured
-pub fn create_app(state: AppState, webhook_path: &str) -> Router {
+pub fn create_app(state: AppState) -> Router {
     Router::new()
-        .route(
-            webhook_path,
-            post(handle_workflow_job_event).with_state(state),
-        )
+        .route("/webhook", post(handle_workflow_job_event).with_state(state))
         .route("/ping", get(ping))
         .route("/health_check", post(health_check))
         .layer(


### PR DESCRIPTION
- Drop --webhook-path/WEBHOOK_PATH and dynamic routing
- Fix server router to hardcode /webhook
- Update README to remove configurability mentions and examples
