### PR TITLE
Modernize build caching for Dockerfile and workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,7 @@
 # Ignore build artifacts and cache
 /target/
 
-# Ignore Git and IDE files
-.git/
+# Ignore IDE files (.git is kept so build.rs / vergen-gitcl can read commit info)
 .gitignore
 *.swp
 *.swo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -22,19 +22,6 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
-
-      - name: Cache Rust dependencies
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,22 +26,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Cache Rust dependencies for Docker build
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: docker-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            docker-${{ runner.os }}-cargo-
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
+        if: github.event_name == 'push'
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -64,7 +53,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -72,6 +61,7 @@ jobs:
           attestations: type=provenance,mode=max
 
       - name: Generate build attestation
+        if: github.event_name == 'push'
         uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -79,6 +69,7 @@ jobs:
           push-to-registry: true
 
       - name: Run security scan
+        if: github.event_name == 'push'
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
@@ -86,6 +77,7 @@ jobs:
           output: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results to GitHub Security tab
+        if: github.event_name == 'push'
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-results.sarif'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,37 @@
-# Multi-stage Dockerfile for spotted-arms
-# Stage 1: Build the Rust application
+# syntax=docker/dockerfile:1
+
 FROM rust:1.95-slim-trixie AS builder
 
-# Install build dependencies
-RUN apt-get update && apt-get install -y \
-    pkg-config \
-    libssl-dev \
-    ca-certificates \
-    build-essential \
-    && rm -rf /var/lib/apt/lists/*
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        pkg-config \
+        libssl-dev \
+        ca-certificates \
+        build-essential \
+        git
 
-# Set the working directory
 WORKDIR /app
 
-# Copy dependency files first for better caching
-COPY Cargo.toml Cargo.lock ./
-
-# Create a dummy main.rs to build dependencies
-RUN mkdir -p src/bin && echo "fn main() {println!(\"hello\");}" > src/bin/spotted-arms.rs && \
-    echo "// dummy lib" > src/lib.rs
-
-# Build dependencies
-RUN cargo build --release --bin spotted-arms
-RUN rm -rf src
-
-# Copy the actual source code
-COPY src ./src
+COPY Cargo.toml Cargo.lock build.rs ./
 COPY .cargo ./.cargo
+COPY src ./src
+COPY .git ./.git
 
-# Build the application in release mode for x86_64
-RUN cargo build --release --bin spotted-arms
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --bin spotted-arms && \
+    cp /app/target/release/spotted-arms /usr/local/bin/spotted-arms
 
-# Stage 2: Create the runtime image using distroless
 FROM gcr.io/distroless/cc-debian13:latest
 
-# Copy the binary from the builder stage
-COPY --from=builder /app/target/release/spotted-arms /usr/local/bin/spotted-arms
+COPY --from=builder /usr/local/bin/spotted-arms /usr/local/bin/spotted-arms
 
-# Create a non-root user for security
 USER 65534:65534
 
-# Expose the default port (can be overridden via PORT env var)
 EXPOSE 3000
 
-# Set the entrypoint
 ENTRYPOINT ["/usr/local/bin/spotted-arms"]


### PR DESCRIPTION
## Summary
- Dockerfile uses BuildKit cache mounts (apt, cargo registry/git, `target/`) instead of the dummy-`main.rs` trick; installs `git` and includes `.git` so `build.rs`/`vergen-gitcl` populates commit metadata.
- `.dockerignore` no longer excludes `.git/` (needed by `vergen-gitcl`).
- `ci.yml`: dropped the manual `actions/cache` step — `setup-rust-toolchain` already caches via Swatinem/rust-cache with better keying and trimming.
- `docker.yml`: dropped the host-side cargo cache step (the Rust build runs inside the Docker builder, so it was never consumed); gated push, attestation, Trivy scan, and registry login on `github.event_name == 'push'` so PRs build-only.

## Test plan
- [ ] CI workflow passes on this PR (build-only, no push)
- [ ] Docker workflow builds on PR without pushing to GHCR
- [ ] After merge to `main`, Docker workflow pushes image, runs attestation, and uploads Trivy SARIF
- [ ] Second CI run is measurably faster than the first (cache hit)