### PR TITLE
Add weekly GHCR cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -2,7 +2,7 @@ name: Cleanup old GHCR versions
 
 on:
   schedule:
-    - cron: '0 3 * * 0'
+    - cron: '0 3 * * 3'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cleanup-ghcr.yml
+++ b/.github/workflows/cleanup-ghcr.yml
@@ -1,0 +1,20 @@
+name: Cleanup old GHCR versions
+
+on:
+  schedule:
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+
+    steps:
+      - name: Delete old container versions
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: spotted-arms
+          package-type: container
+          min-versions-to-keep: 30


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/cleanup-ghcr.yml` — weekly cron (Sun 03:00 UTC) plus `workflow_dispatch`, runs `actions/delete-package-versions@v5` keeping the 30 most-recent container versions.
- After merging, trigger the workflow manually once to flush the ~1300 stale versions (old `sha-*` tags, PR builds from before push-gating, referrer/attestation blobs). Dry-run verified the kept 30 includes the current \`main\` image plus its attestation.

## Notes
- `ignore-versions` was considered but the action matches against the version *name* (digest) for container packages, not tags — so it's a no-op here. Relying on \`min-versions-to-keep\` is sufficient since \`main\` is always among the freshest pushes.
- \`permissions: packages: write\` is the only scope needed; repo-scoped \`GITHUB_TOKEN\` handles auth.

## Test plan
- [ ] Merge and run \`Actions → Cleanup old GHCR versions → Run workflow\` once.
- [ ] Confirm version count drops to ~30 on https://github.com/NathanHowell/spotted-arms/pkgs/container/spotted-arms/versions.
- [ ] Confirm \`ghcr.io/nathanhowell/spotted-arms:main\` still pulls.